### PR TITLE
Updated the Title of the Project --> CryptoExamples

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -40,7 +40,7 @@ exclude:
   - pages/java-keyczar/java-keyczar-crypto-examples/
 # these are the files and directories that jekyll will exclude from the build
 
-feedback_subject_line: Crypto Examples
+feedback_subject_line: CryptoExamples
 
 feedback_email: info@example.com
 # used as a contact email for the Feedback link in the top navigation bar

--- a/_config.yml
+++ b/_config.yml
@@ -3,10 +3,10 @@ repository: kmindi/crypto-examples
 output: web
 # this property is useful for conditional filtering of content that is separate from the PDF.
 
-topnav_title: Crypto Code Examples
+topnav_title: CryptoExamples
 # this appears on the top navigation bar next to the home button
 
-site_title: Crypto Code Examples
+site_title: CryptoExamples
 # this appears in the html browser tab for the site title (seen mostly by search engines, not users)
 
 company_name: Kai Mindermann M.Sc.

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,7 +3,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="{% if page.summary %}{{ page.summary | strip_html | strip_newlines | truncate: 160 }}{% endif %}">
 <meta name="keywords" content="{{page.tags}}{% if page.tags %}, {% endif %} {{page.keywords}}">
-<title>{% if page.permalink == 'index.html' %}{{ page.title }}{% else %}{{ page.title }} | {{ site.site_title }}{% endif %}</title>
+<title>{{ page.title }} | {{ site.site_title }}</title>
 <link rel="stylesheet" href="{{ "css/syntax.css" }}">
 
 <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,7 +3,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="description" content="{% if page.summary %}{{ page.summary | strip_html | strip_newlines | truncate: 160 }}{% endif %}">
 <meta name="keywords" content="{{page.tags}}{% if page.tags %}, {% endif %} {{page.keywords}}">
-<title>{{ page.title }} | {{ site.site_title }}</title>
+<title>{% if page.permalink == 'index.html' %}{{ page.title }}{% else %}{{ page.title }} | {{ site.site_title }}{% endif %}</title>
 <link rel="stylesheet" href="{{ "css/syntax.css" }}">
 
 <link rel="stylesheet" type="text/css" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">

--- a/index.md
+++ b/index.md
@@ -1,5 +1,5 @@
 ---
-title: Introduction
+title: Code examples for common crypto scenarios
 permalink: index.html
 ---
 


### PR DESCRIPTION
- Renamed `Crypto Code Examples` to `CryptoExamples`
- Each subpage is now titled in the browser tab as `subpage-title | CryptoExamples` while the main landing page is titled `Code examples for common crypto scenarios`.